### PR TITLE
ASM-3406 remove asm_decrypt password encryption

### DIFF
--- a/bin/discovery.rb
+++ b/bin/discovery.rb
@@ -17,18 +17,16 @@ opts = Trollop::options do
   opt :username, 'switch username', :type => :string
   opt :password, 'switch password', :type => :string
   opt :timeout, 'command timeout', :default => 240
-  opt :credential_id, 'credential id in database', :type => :string
-  opt :asm_decrypt, 'dummy value for ASM, not used'
   opt :community_string, 'dummy value for ASM, not used'
 end
 
 begin
-  if (opts[:username].nil? || opts[:password].nil?) && opts[:credential_id].nil?
-    puts "Must give username and password parameters, or a valid credential id parameter."
+  if opts[:username].nil? || opts[:password].nil?
+    puts "Must give username and password parameters."
     exit 1
   end
   Timeout.timeout(opts[:timeout]) do
-    device_conf = {:scheme => 'ssh', :host => opts[:server], :port => opts[:port], :password => opts[:password], :user=>opts[:username], :arguments=>{ :credential_id => opts[:credential_id] } }
+    device_conf = {:scheme => 'ssh', :host => opts[:server], :port => opts[:port], :password => opts[:password], :user=>opts[:username] }
     transport = PuppetX::Iom8x4::Transport.new(nil, {:device_config => device_conf})
     facts = transport.facts
   end

--- a/lib/puppet_x/iom_8x4/transport.rb
+++ b/lib/puppet_x/iom_8x4/transport.rb
@@ -10,14 +10,14 @@ module PuppetX
       attr_accessor :enable_password, :switch, :session, :crypt
 
       def initialize(certname, options={})
-          if options[:device_config]
-            device_conf = options[:device_config]
-          else
-            require 'asm/device_management'
-            device_conf = ASM::DeviceManagement.parse_device_config(certname)
-          end
-        scheme = device_conf[:scheme]
+        if options[:device_config]
+          device_conf = options[:device_config]
+        else
+          require 'asm/device_management'
+          device_conf = ASM::DeviceManagement.parse_device_config(certname)
+        end
 
+        device_conf[:arguments] ||= {}
         @enable_password = options[:enable_password] || device_conf[:arguments]['enable']
 
         unless @session


### PR DESCRIPTION
An encrypted device password was passed to the asm-deployer device
management service and written to the device configuration file
url. That password has been deprecated and all puppet-layer code
should use the credential_id argument in preference to that.

Additionally the credential-id argument will no longer be passed to
inventory scripts since it is redundant -- the information contained
in it is already passed as separate plaintext arguments.