### PR TITLE
ASM-8827 Puppet4 Compliance

### DIFF
--- a/lib/puppet_x/iom_8x4/dsl.rb
+++ b/lib/puppet_x/iom_8x4/dsl.rb
@@ -58,7 +58,7 @@ module PuppetX
       def register_new_module(mod, path_addition = "")
         @included_modules ||= []
         unless @included_modules.include?(mod)
-          Puppet::Util::Autoload.new(self, File.join(mod_path_base, path_addition), :wrap => false).load(mod)
+          Puppet::Util::Autoload.new(self, File.join(mod_path_base, path_addition)).load(mod)
           if path_addition.empty?
             mod_const_base.const_get(mod.to_s.capitalize).register(self)
           @included_modules << mod


### PR DESCRIPTION
The :wrap parameter is not valid for puppet 4. I've tested this
to make sure the module still works on the old puppet wth discovery
and basic deployment.

Because a lot of this code was copy-pasted, I have a feeling this
was nevery needed (especially because it's set to false)